### PR TITLE
feat: Add OpenAPI documentation with Scalar UI

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -3,6 +3,7 @@ using RoomBooking.Api.Data;
 using RoomBooking.Api.Middleware;
 using RoomBooking.Api.Services;
 using RoomBooking.Api.Services.Interfaces;
+using Scalar.AspNetCore;
 
 // Load environment variables from .env file (development convenience)
 // Look for .env in repository root (parent directory of src/)
@@ -43,8 +44,20 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 // Register services
 builder.Services.AddScoped<IBuildingService, BuildingService>();
 
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+// Configure OpenAPI with metadata
+builder.Services.AddOpenApi(options =>
+{
+    options.AddDocumentTransformer((document, context, cancellationToken) =>
+    {
+        document.Info = new()
+        {
+            Title = "Room Booking System API",
+            Version = "v1",
+            Description = "Backend API for Room Booking System (PBL 2026)"
+        };
+        return Task.CompletedTask;
+    });
+});
 
 var app = builder.Build();
 
@@ -53,9 +66,11 @@ var app = builder.Build();
 // Global exception handling middleware
 app.UseMiddleware<GlobalExceptionMiddleware>();
 
+// Enable OpenAPI and Scalar UI only in Development
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
+    app.MapOpenApi("/openapi/v1.json");
+    app.MapScalarApiReference();
 }
 
 app.UseHttpsRedirection();

--- a/src/RoomBooking.Api.csproj
+++ b/src/RoomBooking.Api.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="1.2.45" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Configure OpenAPI with API metadata (title, version, description)
- Add Scalar.AspNetCore package for modern documentation UI
- Enable OpenAPI endpoint at /openapi/v1.json
- Enable Scalar UI at /scalar/v1 (Development only)
- Maintain snake_case JSON serialization
- No changes to existing endpoints or business logic